### PR TITLE
feat: Output node locations + in loose mode, version specs & extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ parsePipRequirementsLine(lineContent: string): Requirement | null
 ```
 (null is returned for lines validly lacking a requirement, e.g. empty or comment-only)
 
+Both functions also accept an optional `options` parameter with `includeLocations: true` to get source location information:
+```typescript
+parsePipRequirementsFile(fileContent: string, options: { includeLocations: true }): WithLocation<Requirement>[]
+parsePipRequirementsLine(lineContent: string, options: { includeLocations: true }): WithLocation<Requirement> | null
+```
+
+The `WithLocation<T>` wrapper includes `data` (the parsed requirement) and `location` (with `startIdx` and `endIdx` indicating the character positions in the source).
+
 In both cases a `RequirementsSyntaxError` will be thrown if the provided content contains invalid syntax.
 
 To make use of the resulting data, look up what `Requirement` is made up of in [`types.ts`](https://github.com/Twixes/pip-requirements-js/blob/main/src/).
@@ -30,6 +38,12 @@ To make use of the resulting data, look up what `Requirement` is made up of in [
 There is also a loose mode, which is oriented for processing partially-written requirements. This is useful when handling live code editor input.
 
 `parsePipRequirementsFileLoosely` and `parsePipRequirementsLineLoosely` work the same as their full versions, except they return `LooseProjectNameRequirement` in place of `Requirement`. This means that URL-based requirements are skipped, as are requirements/constraints files.
+
+The loose parsing functions also support the `includeLocations` option:
+```typescript
+parsePipRequirementsFileLoosely(fileContent: string, options: { includeLocations: true }): WithLocation<LooseProjectNameRequirement>[]
+parsePipRequirementsLineLoosely(lineContent: string, options: { includeLocations: true }): WithLocation<LooseProjectNameRequirement> | null
+```
 
 ## Internals
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -175,7 +175,16 @@ const strictParsingTests: Array<[string, string, any]> = [
                         location: { startIdx: 13, endIdx: 22 },
                     },
                 ],
-                extras: ['foo', 'bar'],
+                extras: [
+                    {
+                        data: 'foo',
+                        location: { startIdx: 4, endIdx: 7 },
+                    },
+                    {
+                        data: 'bar',
+                        location: { startIdx: 8, endIdx: 11 },
+                    },
+                ],
                 environmentMarkerTree: undefined,
             },
             location: { startIdx: 0, endIdx: 22 },
@@ -209,7 +218,16 @@ const strictParsingTests: Array<[string, string, any]> = [
                     location: { startIdx: 0, endIdx: 3 },
                 },
                 versionSpec: undefined,
-                extras: ['foo', 'bar'],
+                extras: [
+                    {
+                        data: 'foo',
+                        location: { startIdx: 4, endIdx: 7 },
+                    },
+                    {
+                        data: 'bar',
+                        location: { startIdx: 8, endIdx: 11 },
+                    },
+                ],
                 environmentMarkerTree: { left: 'python_version', operator: '==', right: '"2.7"' },
             },
             location: { startIdx: 0, endIdx: 37 },
@@ -331,7 +349,16 @@ const looseParsingTests: Array<[string, string, any]> = [
                     location: { startIdx: 0, endIdx: 3 },
                 },
                 versionSpec: undefined,
-                extras: ['foo', 'bar'],
+                extras: [
+                    {
+                        data: 'foo',
+                        location: { startIdx: 4, endIdx: 7 },
+                    },
+                    {
+                        data: 'bar',
+                        location: { startIdx: 8, endIdx: 11 },
+                    },
+                ],
             },
             location: { startIdx: 0, endIdx: 38 },
         },
@@ -467,7 +494,16 @@ const looseParsingTests: Array<[string, string, any]> = [
                     location: { startIdx: 0, endIdx: 3 },
                 },
                 versionSpec: undefined,
-                extras: ['extra1', 'extra2'],
+                extras: [
+                    {
+                        data: 'extra1',
+                        location: { startIdx: 4, endIdx: 10 },
+                    },
+                    {
+                        data: 'extra2',
+                        location: { startIdx: 11, endIdx: 17 },
+                    },
+                ],
             },
             location: { startIdx: 0, endIdx: 17 },
         },
@@ -499,7 +535,16 @@ const looseParsingTests: Array<[string, string, any]> = [
                     location: { startIdx: 0, endIdx: 3 },
                 },
                 versionSpec: undefined,
-                extras: ['extra1', 'extra2'],
+                extras: [
+                    {
+                        data: 'extra1',
+                        location: { startIdx: 4, endIdx: 10 },
+                    },
+                    {
+                        data: 'extra2',
+                        location: { startIdx: 11, endIdx: 17 },
+                    },
+                ],
             },
             location: { startIdx: 0, endIdx: 19 },
         },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -109,6 +109,18 @@ describe('parsePipRequirementLineLoosely', () => {
         expect(requirement).toEqual({
             type: 'ProjectName',
             name: 'pip',
+            versionSpec: [{ operator: '=' }],
+        })
+    })
+    it('should parse a requirement with multiple version specs', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip>=2,<3')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [
+                { operator: '>=', version: '2' },
+                { operator: '<', version: '3' },
+            ],
         })
     })
     it('should parse an in-flight requirement with a random environment marker', () => {
@@ -116,6 +128,7 @@ describe('parsePipRequirementLineLoosely', () => {
         expect(requirement).toEqual({
             type: 'ProjectName',
             name: 'hope',
+            versionSpec: [{ operator: '=', version: '2.0' }],
         })
     })
     it('should parse a name-based project requirement with extras, environment markers, and a comment', () => {
@@ -123,6 +136,7 @@ describe('parsePipRequirementLineLoosely', () => {
         expect(requirement).toEqual({
             type: 'ProjectName',
             name: 'pip',
+            extras: ['foo', 'bar'],
         })
     })
     it('should ignore a URL-based project requirement', () => {
@@ -136,5 +150,496 @@ describe('parsePipRequirementLineLoosely', () => {
     it('should ignore a comment-only requirement', () => {
         const requirement = parsePipRequirementsLineLoosely('# text')
         expect(requirement).toBeNull()
+    })
+
+    // Edge cases for incomplete version operators
+    it('should parse incomplete version operators without versions', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip >')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [{ operator: '>' }],
+        })
+    })
+    it('should parse multiple incomplete version operators', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip >=, <')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [{ operator: '>=' }, { operator: '<' }],
+        })
+    })
+    it('should parse malformed version operators', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip =!')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [{ operator: '=!' }],
+        })
+    })
+    it('should parse repeated operator characters', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip ===1.0')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [{ operator: '===', version: '1.0' }],
+        })
+    })
+
+    // Edge cases for incomplete extras
+    it('should parse extras with missing closing bracket', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip[extra1,extra2')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            extras: ['extra1', 'extra2'],
+        })
+    })
+    it('should parse empty extras with missing closing bracket', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip[')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            extras: [],
+        })
+    })
+    it('should parse extras with trailing comma', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip[extra1,extra2,]')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            extras: ['extra1', 'extra2'],
+        })
+    })
+
+    // Edge cases for incomplete parentheses in version specs
+    it('should parse parenthesized version spec with missing closing paren', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip (>=1.0')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [{ operator: '>=', version: '1.0' }],
+        })
+    })
+    it('should parse empty parentheses with missing closing paren', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip (')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [],
+        })
+    })
+    it('should parse version spec with trailing comma in parentheses', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip (>=1.0,<2.0,)')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [
+                { operator: '>=', version: '1.0' },
+                { operator: '<', version: '2.0' },
+            ],
+        })
+    })
+
+    // Whitespace handling edge cases
+    it('should handle excessive whitespace', () => {
+        const requirement = parsePipRequirementsLineLoosely('  pip   [  extra1  ,  extra2  ]   >=   1.0  ')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            extras: ['extra1', 'extra2'],
+            versionSpec: [{ operator: '>=', version: '1.0' }],
+        })
+    })
+    it('should handle tabs and mixed whitespace', () => {
+        const requirement = parsePipRequirementsLineLoosely('\tpip\t>=\t1.0\t')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [{ operator: '>=', version: '1.0' }],
+        })
+    })
+
+    // Empty and minimal requirements
+    it('should parse just a package name', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+        })
+    })
+    it('should parse package name with just empty parentheses', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip()')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [],
+        })
+    })
+    it('should parse package name with just empty brackets', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip[]')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            extras: [],
+        })
+    })
+    it('should ignore empty lines', () => {
+        const requirement = parsePipRequirementsLineLoosely('')
+        expect(requirement).toBeNull()
+    })
+    it('should ignore whitespace-only lines', () => {
+        const requirement = parsePipRequirementsLineLoosely('   \t   ')
+        expect(requirement).toBeNull()
+    })
+
+    // Complex edge cases combining multiple incomplete elements
+    it('should parse complex incomplete requirement with everything partial', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip[extra1,extra2 (>=1.0,<; some invalid marker')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            extras: ['extra1', 'extra2'],
+            versionSpec: [{ operator: '>=', version: '1.0' }, { operator: '<' }],
+        })
+    })
+    it('should parse version specs with mixed completeness', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip >=1.0, <, !=2.0, >')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [
+                { operator: '>=', version: '1.0' },
+                { operator: '<' },
+                { operator: '!=', version: '2.0' },
+                { operator: '>' },
+            ],
+        })
+    })
+
+    // Package names with special characters
+    it('should parse package names with hyphens and underscores', () => {
+        const requirement = parsePipRequirementsLineLoosely('my-package_name >= 1.0')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'my-package_name',
+            versionSpec: [{ operator: '>=', version: '1.0' }],
+        })
+    })
+    it('should parse package names with dots', () => {
+        const requirement = parsePipRequirementsLineLoosely('my.package.name == 1.0')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'my.package.name',
+            versionSpec: [{ operator: '==', version: '1.0' }],
+        })
+    })
+
+    // Version strings with special characters
+    it('should parse versions with special characters', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip == 1.0.0-alpha.1+build.123')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [{ operator: '==', version: '1.0.0-alpha.1+build.123' }],
+        })
+    })
+    it('should parse versions with wildcards', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip == 1.0.*')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [{ operator: '==', version: '1.0.*' }],
+        })
+    })
+
+    // Progressive typing scenarios - character by character
+    it('should parse single character package names', () => {
+        const requirement = parsePipRequirementsLineLoosely('a')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'a',
+        })
+    })
+    it('should parse partial package names being typed', () => {
+        const requirement = parsePipRequirementsLineLoosely('requ')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'requ',
+        })
+    })
+    it('should parse package name with start of version operator', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip =')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [{ operator: '=' }],
+        })
+    })
+    it('should parse package name with partial double equals', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip ==')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [{ operator: '==' }],
+        })
+    })
+    it('should parse package name with incomplete version number', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip == 1')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [{ operator: '==', version: '1' }],
+        })
+    })
+    it('should parse package name with partial dot version', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip == 1.')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [{ operator: '==', version: '1.' }],
+        })
+    })
+    it('should parse package name with partial second version number', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip == 1.2')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [{ operator: '==', version: '1.2' }],
+        })
+    })
+
+    // Auto-completion scenarios
+    it('should parse package name with opening bracket for extras', () => {
+        const requirement = parsePipRequirementsLineLoosely('requests[')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'requests',
+            extras: [],
+        })
+    })
+    it('should parse package name with partial extra being typed', () => {
+        const requirement = parsePipRequirementsLineLoosely('requests[sec')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'requests',
+            extras: ['sec'],
+        })
+    })
+    it('should parse package name with complete extra and comma', () => {
+        const requirement = parsePipRequirementsLineLoosely('requests[security,')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'requests',
+            extras: ['security'],
+        })
+    })
+    it('should parse package name with opening parenthesis for version', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip (')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [],
+        })
+    })
+    it('should parse package name with opening parenthesis and partial operator', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip (>')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [{ operator: '>' }],
+        })
+    })
+
+    // Typos and corrections
+    it('should parse package name with wrong operator being corrected', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip =<')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [{ operator: '=<' }],
+        })
+    })
+    it('should parse package name with double operators', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip >>>')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [{ operator: '>>>' }],
+        })
+    })
+    it('should parse package name with mixed operator characters', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip >=<')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [{ operator: '>=<' }],
+        })
+    })
+    it('should parse package name with incomplete version after space', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip == 1.')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [{ operator: '==', version: '1.' }],
+        })
+    })
+
+    // Copy-paste fragments and partial inputs
+    it('should parse incomplete requirements line ending abruptly', () => {
+        const requirement = parsePipRequirementsLineLoosely('django>=3.2,<4.0,!=3.2.1')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'django',
+            versionSpec: [
+                { operator: '>=', version: '3.2' },
+                { operator: '<', version: '4.0' },
+                { operator: '!=', version: '3.2.1' },
+            ],
+        })
+    })
+    it('should parse requirement with dangling comma', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip>=1.0,')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [{ operator: '>=', version: '1.0' }],
+        })
+    })
+    it('should parse requirement with multiple dangling commas', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip>=1.0,,,')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [{ operator: '>=', version: '1.0' }],
+        })
+    })
+    it('should parse requirement with space before comma', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip>=1.0 ,<2.0')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [
+                { operator: '>=', version: '1.0' },
+                { operator: '<', version: '2.0' },
+            ],
+        })
+    })
+
+    // Complex progressive typing with multiple elements
+    it('should parse progressive complex requirement building', () => {
+        const requirement = parsePipRequirementsLineLoosely('requests[security,socks](>=2.25.1,<3.0')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'requests',
+            extras: ['security', 'socks'],
+            versionSpec: [
+                { operator: '>=', version: '2.25.1' },
+                { operator: '<', version: '3.0' },
+            ],
+        })
+    })
+    it('should parse package with extras and incomplete version in parentheses', () => {
+        const requirement = parsePipRequirementsLineLoosely('package[extra](==')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'package',
+            extras: ['extra'],
+            versionSpec: [{ operator: '==' }],
+        })
+    })
+    it('should parse package with incomplete extras and version', () => {
+        const requirement = parsePipRequirementsLineLoosely('package[extra>=1.0')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'package',
+            extras: ['extra'],
+            versionSpec: [{ operator: '>=', version: '1.0' }],
+        })
+    })
+
+    // Edge cases with numbers and special characters in names/versions
+    it('should parse package names starting with numbers', () => {
+        const requirement = parsePipRequirementsLineLoosely('2to3')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: '2to3',
+        })
+    })
+    it('should parse package names with numbers and special chars', () => {
+        const requirement = parsePipRequirementsLineLoosely('py2-ipaddress >= 3.4')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'py2-ipaddress',
+            versionSpec: [{ operator: '>=', version: '3.4' }],
+        })
+    })
+    it('should parse alpha/beta/rc versions being typed', () => {
+        const requirement = parsePipRequirementsLineLoosely('package == 1.0a')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'package',
+            versionSpec: [{ operator: '==', version: '1.0a' }],
+        })
+    })
+    it('should parse dev versions being typed', () => {
+        const requirement = parsePipRequirementsLineLoosely('package == 1.0.dev')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'package',
+            versionSpec: [{ operator: '==', version: '1.0.dev' }],
+        })
+    })
+
+    // Realistic backspacing scenarios (what's left after partial deletion)
+    it('should parse after backspacing part of version', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip == 1.0.')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [{ operator: '==', version: '1.0.' }],
+        })
+    })
+    it('should parse after backspacing closing bracket', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip[extra')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            extras: ['extra'],
+        })
+    })
+    it('should parse after backspacing part of operator', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip >')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [{ operator: '>' }],
+        })
+    })
+
+    // Environment marker edge cases
+    it('should parse with incomplete environment marker', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip >= 1.0 ; python_version')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [{ operator: '>=', version: '1.0' }],
+        })
+    })
+    it('should parse with semicolon but no marker', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip >= 1.0 ;')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [{ operator: '>=', version: '1.0' }],
+        })
+    })
+    it('should parse with semicolon and partial marker text', () => {
+        const requirement = parsePipRequirementsLineLoosely('pip >= 1.0 ; sys_plat')
+        expect(requirement).toEqual({
+            type: 'ProjectName',
+            name: 'pip',
+            versionSpec: [{ operator: '>=', version: '1.0' }],
+        })
     })
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,645 +1,582 @@
 import { parsePipRequirementsLine, parsePipRequirementsLineLoosely } from '.'
+import { WithLocation } from './types'
+
+// Helper function to recursively strip location data from WithLocation objects
+function stripLocationData<T>(obj: WithLocation<T> | T | null | undefined): T | null | undefined {
+    if (obj === null || obj === undefined) {
+        return obj
+    }
+
+    if (typeof obj === 'object' && obj !== null && 'data' in obj && 'location' in obj) {
+        // This is a WithLocation wrapper, extract and process the data
+        return stripLocationData((obj as WithLocation<any>).data)
+    }
+
+    if (Array.isArray(obj)) {
+        return obj.map((item) => stripLocationData(item)) as any
+    }
+
+    if (typeof obj === 'object' && obj !== null) {
+        const result: any = {}
+        for (const [key, value] of Object.entries(obj)) {
+            result[key] = stripLocationData(value)
+        }
+        return result
+    }
+
+    return obj
+}
+
+// Strict parsing test datasets
+const strictParsingTests: Array<[string, string, any]> = [
+    [
+        'should parse a version matching name-based project requirement',
+        'pip == 22.0.2',
+        {
+            data: {
+                type: 'ProjectName',
+                name: {
+                    data: 'pip',
+                    location: { startIdx: 0, endIdx: 3 },
+                },
+                versionSpec: [
+                    {
+                        data: {
+                            operator: {
+                                data: '==',
+                                location: { startIdx: 4, endIdx: 6 },
+                            },
+                            version: {
+                                data: '22.0.2',
+                                location: { startIdx: 7, endIdx: 13 },
+                            },
+                        },
+                        location: { startIdx: 4, endIdx: 13 },
+                    },
+                ],
+                extras: undefined,
+                environmentMarkerTree: undefined,
+            },
+            location: { startIdx: 0, endIdx: 13 },
+        },
+    ],
+    [
+        'should parse a parenthesized version matching name-based project requirement',
+        'pip ( == 22.0.2 )',
+        {
+            data: {
+                type: 'ProjectName',
+                name: {
+                    data: 'pip',
+                    location: { startIdx: 0, endIdx: 3 },
+                },
+                versionSpec: [
+                    {
+                        data: {
+                            operator: {
+                                data: '==',
+                                location: { startIdx: 6, endIdx: 8 },
+                            },
+                            version: {
+                                data: '22.0.2',
+                                location: { startIdx: 9, endIdx: 15 },
+                            },
+                        },
+                        location: { startIdx: 6, endIdx: 15 },
+                    },
+                ],
+                extras: undefined,
+                environmentMarkerTree: undefined,
+            },
+            location: { startIdx: 0, endIdx: 17 },
+        },
+    ],
+    [
+        'should parse a parenthesized empty version spec name-based project requirement',
+        'pip()',
+        {
+            data: {
+                type: 'ProjectName',
+                name: {
+                    data: 'pip',
+                    location: { startIdx: 0, endIdx: 3 },
+                },
+                versionSpec: [], // This is not undefined because of the parentheses
+                extras: undefined,
+                environmentMarkerTree: undefined,
+            },
+            location: { startIdx: 0, endIdx: 5 },
+        },
+    ],
+    [
+        'should parse a URL-based project requirement',
+        'pip @ https://x.com/y.zip',
+        {
+            data: {
+                type: 'ProjectURL',
+                name: {
+                    data: 'pip',
+                    location: { startIdx: 0, endIdx: 3 },
+                },
+                url: {
+                    data: 'https://x.com/y.zip',
+                    location: { startIdx: 6, endIdx: 25 },
+                },
+                extras: undefined,
+                environmentMarkerTree: undefined,
+            },
+            location: { startIdx: 0, endIdx: 25 },
+        },
+    ],
+    [
+        'should parse a requirements file requirement',
+        '-r requirements.txt',
+        {
+            data: {
+                type: 'RequirementsFile',
+                path: 'requirements.txt',
+            },
+            location: { startIdx: 0, endIdx: 19 },
+        },
+    ],
+    [
+        'should parse a constraints file requirement',
+        '-c versionSpec.txt',
+        {
+            data: {
+                type: 'ConstraintsFile',
+                path: 'versionSpec.txt',
+            },
+            location: { startIdx: 0, endIdx: 18 },
+        },
+    ],
+    [
+        'should parse a name-based project requirement with extras',
+        'pip[foo,bar] == 22.0.2',
+        {
+            data: {
+                type: 'ProjectName',
+                name: {
+                    data: 'pip',
+                    location: { startIdx: 0, endIdx: 3 },
+                },
+                versionSpec: [
+                    {
+                        data: {
+                            operator: {
+                                data: '==',
+                                location: { startIdx: 13, endIdx: 15 },
+                            },
+                            version: {
+                                data: '22.0.2',
+                                location: { startIdx: 16, endIdx: 22 },
+                            },
+                        },
+                        location: { startIdx: 13, endIdx: 22 },
+                    },
+                ],
+                extras: ['foo', 'bar'],
+                environmentMarkerTree: undefined,
+            },
+            location: { startIdx: 0, endIdx: 22 },
+        },
+    ],
+    [
+        'should parse a name-based project requirement with environment markers',
+        'pip; python_version == "2.7"',
+        {
+            data: {
+                type: 'ProjectName',
+                name: {
+                    data: 'pip',
+                    location: { startIdx: 0, endIdx: 3 },
+                },
+                versionSpec: undefined,
+                extras: undefined,
+                environmentMarkerTree: { left: 'python_version', operator: '==', right: '"2.7"' },
+            },
+            location: { startIdx: 0, endIdx: 28 },
+        },
+    ],
+    [
+        'should parse a name-based project requirement with extras, environment markers, and a comment',
+        'pip[foo,bar]; python_version == "2.7" # xyz ',
+        {
+            data: {
+                type: 'ProjectName',
+                name: {
+                    data: 'pip',
+                    location: { startIdx: 0, endIdx: 3 },
+                },
+                versionSpec: undefined,
+                extras: ['foo', 'bar'],
+                environmentMarkerTree: { left: 'python_version', operator: '==', right: '"2.7"' },
+            },
+            location: { startIdx: 0, endIdx: 37 },
+        },
+    ],
+    ['should ignore a comment', ' # xyz ', null],
+    ['should ignore a blank line', '', null],
+]
+
+// Loose parsing test datasets
+const looseParsingTests: Array<[string, string, any]> = [
+    [
+        'should parse a basic in-flight requirement',
+        'pip = ',
+        {
+            data: {
+                type: 'ProjectName',
+                name: {
+                    data: 'pip',
+                    location: { startIdx: 0, endIdx: 3 },
+                },
+                versionSpec: [
+                    {
+                        data: {
+                            operator: {
+                                data: '=',
+                                location: { startIdx: 4, endIdx: 5 },
+                            },
+                        },
+                        location: { startIdx: 4, endIdx: 5 },
+                    },
+                ],
+                extras: undefined,
+            },
+            location: { startIdx: 0, endIdx: 5 },
+        },
+    ],
+    [
+        'should parse a requirement with multiple version specs',
+        'pip>=2,<3',
+        {
+            data: {
+                type: 'ProjectName',
+                name: {
+                    data: 'pip',
+                    location: { startIdx: 0, endIdx: 3 },
+                },
+                versionSpec: [
+                    {
+                        data: {
+                            operator: {
+                                data: '>=',
+                                location: { startIdx: 3, endIdx: 5 },
+                            },
+                            version: {
+                                data: '2',
+                                location: { startIdx: 5, endIdx: 6 },
+                            },
+                        },
+                        location: { startIdx: 3, endIdx: 6 },
+                    },
+                    {
+                        data: {
+                            operator: {
+                                data: '<',
+                                location: { startIdx: 7, endIdx: 8 },
+                            },
+                            version: {
+                                data: '3',
+                                location: { startIdx: 8, endIdx: 9 },
+                            },
+                        },
+                        location: { startIdx: 7, endIdx: 9 },
+                    },
+                ],
+                extras: undefined,
+            },
+            location: { startIdx: 0, endIdx: 9 },
+        },
+    ],
+    [
+        'should parse an in-flight requirement with a random environment marker',
+        'hope = 2.0 ; xds',
+        {
+            data: {
+                type: 'ProjectName',
+                name: {
+                    data: 'hope',
+                    location: { startIdx: 0, endIdx: 4 },
+                },
+                versionSpec: [
+                    {
+                        data: {
+                            operator: {
+                                data: '=',
+                                location: { startIdx: 5, endIdx: 6 },
+                            },
+                            version: {
+                                data: '2.0',
+                                location: { startIdx: 7, endIdx: 10 },
+                            },
+                        },
+                        location: { startIdx: 5, endIdx: 10 },
+                    },
+                ],
+                extras: undefined,
+            },
+            location: { startIdx: 0, endIdx: 16 },
+        },
+    ],
+    [
+        'should parse a name-based project requirement with extras, environment markers, and a comment',
+        'pip[foo,bar]; python_version == "2.7" # xyz ',
+        {
+            data: {
+                type: 'ProjectName',
+                name: {
+                    data: 'pip',
+                    location: { startIdx: 0, endIdx: 3 },
+                },
+                versionSpec: undefined,
+                extras: ['foo', 'bar'],
+            },
+            location: { startIdx: 0, endIdx: 38 },
+        },
+    ],
+    ['should ignore a URL-based project requirement', 'pip @ https://x.com/y.zip', null],
+    ['should ignore a requirements file requirement', '-r requirements.txt', null],
+    ['should ignore a comment-only requirement', '# text', null],
+    [
+        'should parse incomplete version operators without versions',
+        'pip >',
+        {
+            data: {
+                type: 'ProjectName',
+                name: {
+                    data: 'pip',
+                    location: { startIdx: 0, endIdx: 3 },
+                },
+                versionSpec: [
+                    {
+                        data: {
+                            operator: {
+                                data: '>',
+                                location: { startIdx: 4, endIdx: 5 },
+                            },
+                        },
+                        location: { startIdx: 4, endIdx: 5 },
+                    },
+                ],
+                extras: undefined,
+            },
+            location: { startIdx: 0, endIdx: 5 },
+        },
+    ],
+    [
+        'should parse multiple incomplete version operators',
+        'pip >=, <',
+        {
+            data: {
+                type: 'ProjectName',
+                name: {
+                    data: 'pip',
+                    location: { startIdx: 0, endIdx: 3 },
+                },
+                versionSpec: [
+                    {
+                        data: {
+                            operator: {
+                                data: '>=',
+                                location: { startIdx: 4, endIdx: 6 },
+                            },
+                        },
+                        location: { startIdx: 4, endIdx: 6 },
+                    },
+                    {
+                        data: {
+                            operator: {
+                                data: '<',
+                                location: { startIdx: 8, endIdx: 9 },
+                            },
+                        },
+                        location: { startIdx: 8, endIdx: 9 },
+                    },
+                ],
+                extras: undefined,
+            },
+            location: { startIdx: 0, endIdx: 9 },
+        },
+    ],
+    [
+        'should parse malformed version operators',
+        'pip =!',
+        {
+            data: {
+                type: 'ProjectName',
+                name: {
+                    data: 'pip',
+                    location: { startIdx: 0, endIdx: 3 },
+                },
+                versionSpec: [
+                    {
+                        data: {
+                            operator: {
+                                data: '=!',
+                                location: { startIdx: 4, endIdx: 6 },
+                            },
+                        },
+                        location: { startIdx: 4, endIdx: 6 },
+                    },
+                ],
+                extras: undefined,
+            },
+            location: { startIdx: 0, endIdx: 6 },
+        },
+    ],
+    [
+        'should parse repeated operator characters',
+        'pip ===1.0',
+        {
+            data: {
+                type: 'ProjectName',
+                name: {
+                    data: 'pip',
+                    location: { startIdx: 0, endIdx: 3 },
+                },
+                versionSpec: [
+                    {
+                        data: {
+                            operator: {
+                                data: '===',
+                                location: { startIdx: 4, endIdx: 7 },
+                            },
+                            version: {
+                                data: '1.0',
+                                location: { startIdx: 7, endIdx: 10 },
+                            },
+                        },
+                        location: { startIdx: 4, endIdx: 10 },
+                    },
+                ],
+                extras: undefined,
+            },
+            location: { startIdx: 0, endIdx: 10 },
+        },
+    ],
+    [
+        'should parse extras with missing closing bracket',
+        'pip[extra1,extra2',
+        {
+            data: {
+                type: 'ProjectName',
+                name: {
+                    data: 'pip',
+                    location: { startIdx: 0, endIdx: 3 },
+                },
+                versionSpec: undefined,
+                extras: ['extra1', 'extra2'],
+            },
+            location: { startIdx: 0, endIdx: 17 },
+        },
+    ],
+    [
+        'should parse empty extras with missing closing bracket',
+        'pip[',
+        {
+            data: {
+                type: 'ProjectName',
+                name: {
+                    data: 'pip',
+                    location: { startIdx: 0, endIdx: 3 },
+                },
+                versionSpec: undefined,
+                extras: [],
+            },
+            location: { startIdx: 0, endIdx: 4 },
+        },
+    ],
+    [
+        'should parse extras with trailing comma',
+        'pip[extra1,extra2,]',
+        {
+            data: {
+                type: 'ProjectName',
+                name: {
+                    data: 'pip',
+                    location: { startIdx: 0, endIdx: 3 },
+                },
+                versionSpec: undefined,
+                extras: ['extra1', 'extra2'],
+            },
+            location: { startIdx: 0, endIdx: 19 },
+        },
+    ],
+    [
+        'should parse just a package name',
+        'pip',
+        {
+            data: {
+                type: 'ProjectName',
+                name: {
+                    data: 'pip',
+                    location: { startIdx: 0, endIdx: 3 },
+                },
+                versionSpec: undefined,
+                extras: undefined,
+            },
+            location: { startIdx: 0, endIdx: 3 },
+        },
+    ],
+    ['should ignore empty lines', '', null],
+    ['should ignore whitespace-only lines', '   \t   ', null],
+]
 
 describe('parsePipRequirementsLine', () => {
-    it('should parse a version matching name-based project requirement', () => {
-        const requirement = parsePipRequirementsLine('pip == 22.0.2')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [
-                {
-                    operator: '==',
-                    version: '22.0.2',
-                },
-            ],
+    describe('without location tracking', () => {
+        strictParsingTests.forEach(([explanation, input, expectedWithLocation]) => {
+            if (explanation === 'should throw an error if the syntax is wrong') {
+                it(explanation, () => {
+                    expect(() => parsePipRequirementsLine('pip???')).toThrowError(
+                        'Failed to parse requirements line. Line 1, col 4: expected end of input'
+                    )
+                })
+                return
+            }
+
+            it(explanation, () => {
+                const requirement = parsePipRequirementsLine(input)
+                const expected = stripLocationData(expectedWithLocation)
+                expect(requirement).toEqual(expected)
+            })
+        })
+
+        it('should throw an error if the syntax is wrong', () => {
+            expect(() => parsePipRequirementsLine('pip???')).toThrowError(
+                'Failed to parse requirements line. Line 1, col 4: expected end of input'
+            )
         })
     })
-    it('should parse a parenthesized version matching name-based project requirement', () => {
-        const requirement = parsePipRequirementsLine('pip ( == 22.0.2 )')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [
-                {
-                    operator: '==',
-                    version: '22.0.2',
-                },
-            ],
+
+    describe('with location tracking', () => {
+        strictParsingTests.forEach(([explanation, input, expected]) => {
+            it(explanation, () => {
+                const requirement = parsePipRequirementsLine(input, { includeLocations: true })
+                expect(requirement).toEqual(expected)
+            })
         })
-    })
-    it('should parse a parenthesized empty version spec name-based project requirement', () => {
-        const requirement = parsePipRequirementsLine('pip()')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [], // This is not undefined because of the parentheses
-        })
-    })
-    it('should parse a URL-based project requirement', () => {
-        const requirement = parsePipRequirementsLine('pip @ https://x.com/y.zip')
-        expect(requirement).toEqual({
-            type: 'ProjectURL',
-            name: 'pip',
-            url: 'https://x.com/y.zip',
-        })
-    })
-    it('should parse a requirements file requirement', () => {
-        const requirement = parsePipRequirementsLine('-r requirements.txt')
-        expect(requirement).toEqual({
-            type: 'RequirementsFile',
-            path: 'requirements.txt',
-        })
-    })
-    it('should parse a constraints file requirement', () => {
-        const requirement = parsePipRequirementsLine('-c versionSpec.txt')
-        expect(requirement).toEqual({
-            type: 'ConstraintsFile',
-            path: 'versionSpec.txt',
-        })
-    })
-    it('should parse a name-based project requirement with extras', () => {
-        const requirement = parsePipRequirementsLine('pip[foo,bar] == 22.0.2')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [
-                {
-                    operator: '==',
-                    version: '22.0.2',
-                },
-            ],
-            extras: ['foo', 'bar'],
-        })
-    })
-    it('should parse a name-based project requirement with environment markers', () => {
-        const requirement = parsePipRequirementsLine('pip; python_version == "2.7"')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            environmentMarkerTree: { left: 'python_version', operator: '==', right: '"2.7"' },
-        })
-    })
-    it('should parse a name-based project requirement with extras, environment markers, and a comment', () => {
-        const requirement = parsePipRequirementsLine('pip[foo,bar]; python_version == "2.7" # xyz ')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            extras: ['foo', 'bar'],
-            environmentMarkerTree: { left: 'python_version', operator: '==', right: '"2.7"' },
-        })
-    })
-    it('should ignore a comment', () => {
-        const requirement = parsePipRequirementsLine(' # xyz ')
-        expect(requirement).toBeNull()
-    })
-    it('should ignore a blank line', () => {
-        const requirement = parsePipRequirementsLine('')
-        expect(requirement).toBeNull()
-    })
-    it('should throw an error if the syntax is wrong', () => {
-        expect(() => parsePipRequirementsLine('pip???')).toThrowError(
-            'Failed to parse requirements line. Line 1, col 4: expected end of input'
-        )
     })
 })
 
-describe('parsePipRequirementLineLoosely', () => {
-    it('should parse a basic in-flight requirement', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip = ')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [{ operator: '=' }],
-        })
-    })
-    it('should parse a requirement with multiple version specs', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip>=2,<3')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [
-                { operator: '>=', version: '2' },
-                { operator: '<', version: '3' },
-            ],
-        })
-    })
-    it('should parse an in-flight requirement with a random environment marker', () => {
-        const requirement = parsePipRequirementsLineLoosely('hope = 2.0 ; xds')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'hope',
-            versionSpec: [{ operator: '=', version: '2.0' }],
-        })
-    })
-    it('should parse a name-based project requirement with extras, environment markers, and a comment', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip[foo,bar]; python_version == "2.7" # xyz ')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            extras: ['foo', 'bar'],
-        })
-    })
-    it('should ignore a URL-based project requirement', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip @ https://x.com/y.zip')
-        expect(requirement).toBeNull()
-    })
-    it('should ignore a requirements file requirement', () => {
-        const requirement = parsePipRequirementsLineLoosely('-r requirements.txt')
-        expect(requirement).toBeNull()
-    })
-    it('should ignore a comment-only requirement', () => {
-        const requirement = parsePipRequirementsLineLoosely('# text')
-        expect(requirement).toBeNull()
-    })
-
-    // Edge cases for incomplete version operators
-    it('should parse incomplete version operators without versions', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip >')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [{ operator: '>' }],
-        })
-    })
-    it('should parse multiple incomplete version operators', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip >=, <')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [{ operator: '>=' }, { operator: '<' }],
-        })
-    })
-    it('should parse malformed version operators', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip =!')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [{ operator: '=!' }],
-        })
-    })
-    it('should parse repeated operator characters', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip ===1.0')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [{ operator: '===', version: '1.0' }],
+describe('parsePipRequirementsLineLoosely', () => {
+    describe('without location tracking', () => {
+        looseParsingTests.forEach(([explanation, input, expectedWithLocation]) => {
+            it(explanation, () => {
+                const requirement = parsePipRequirementsLineLoosely(input)
+                const expected = stripLocationData(expectedWithLocation)
+                expect(requirement).toEqual(expected)
+            })
         })
     })
 
-    // Edge cases for incomplete extras
-    it('should parse extras with missing closing bracket', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip[extra1,extra2')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            extras: ['extra1', 'extra2'],
-        })
-    })
-    it('should parse empty extras with missing closing bracket', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip[')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            extras: [],
-        })
-    })
-    it('should parse extras with trailing comma', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip[extra1,extra2,]')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            extras: ['extra1', 'extra2'],
-        })
-    })
-
-    // Edge cases for incomplete parentheses in version specs
-    it('should parse parenthesized version spec with missing closing paren', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip (>=1.0')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [{ operator: '>=', version: '1.0' }],
-        })
-    })
-    it('should parse empty parentheses with missing closing paren', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip (')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [],
-        })
-    })
-    it('should parse version spec with trailing comma in parentheses', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip (>=1.0,<2.0,)')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [
-                { operator: '>=', version: '1.0' },
-                { operator: '<', version: '2.0' },
-            ],
-        })
-    })
-
-    // Whitespace handling edge cases
-    it('should handle excessive whitespace', () => {
-        const requirement = parsePipRequirementsLineLoosely('  pip   [  extra1  ,  extra2  ]   >=   1.0  ')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            extras: ['extra1', 'extra2'],
-            versionSpec: [{ operator: '>=', version: '1.0' }],
-        })
-    })
-    it('should handle tabs and mixed whitespace', () => {
-        const requirement = parsePipRequirementsLineLoosely('\tpip\t>=\t1.0\t')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [{ operator: '>=', version: '1.0' }],
-        })
-    })
-
-    // Empty and minimal requirements
-    it('should parse just a package name', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-        })
-    })
-    it('should parse package name with just empty parentheses', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip()')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [],
-        })
-    })
-    it('should parse package name with just empty brackets', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip[]')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            extras: [],
-        })
-    })
-    it('should ignore empty lines', () => {
-        const requirement = parsePipRequirementsLineLoosely('')
-        expect(requirement).toBeNull()
-    })
-    it('should ignore whitespace-only lines', () => {
-        const requirement = parsePipRequirementsLineLoosely('   \t   ')
-        expect(requirement).toBeNull()
-    })
-
-    // Complex edge cases combining multiple incomplete elements
-    it('should parse complex incomplete requirement with everything partial', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip[extra1,extra2 (>=1.0,<; some invalid marker')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            extras: ['extra1', 'extra2'],
-            versionSpec: [{ operator: '>=', version: '1.0' }, { operator: '<' }],
-        })
-    })
-    it('should parse version specs with mixed completeness', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip >=1.0, <, !=2.0, >')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [
-                { operator: '>=', version: '1.0' },
-                { operator: '<' },
-                { operator: '!=', version: '2.0' },
-                { operator: '>' },
-            ],
-        })
-    })
-
-    // Package names with special characters
-    it('should parse package names with hyphens and underscores', () => {
-        const requirement = parsePipRequirementsLineLoosely('my-package_name >= 1.0')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'my-package_name',
-            versionSpec: [{ operator: '>=', version: '1.0' }],
-        })
-    })
-    it('should parse package names with dots', () => {
-        const requirement = parsePipRequirementsLineLoosely('my.package.name == 1.0')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'my.package.name',
-            versionSpec: [{ operator: '==', version: '1.0' }],
-        })
-    })
-
-    // Version strings with special characters
-    it('should parse versions with special characters', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip == 1.0.0-alpha.1+build.123')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [{ operator: '==', version: '1.0.0-alpha.1+build.123' }],
-        })
-    })
-    it('should parse versions with wildcards', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip == 1.0.*')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [{ operator: '==', version: '1.0.*' }],
-        })
-    })
-
-    // Progressive typing scenarios - character by character
-    it('should parse single character package names', () => {
-        const requirement = parsePipRequirementsLineLoosely('a')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'a',
-        })
-    })
-    it('should parse partial package names being typed', () => {
-        const requirement = parsePipRequirementsLineLoosely('requ')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'requ',
-        })
-    })
-    it('should parse package name with start of version operator', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip =')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [{ operator: '=' }],
-        })
-    })
-    it('should parse package name with partial double equals', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip ==')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [{ operator: '==' }],
-        })
-    })
-    it('should parse package name with incomplete version number', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip == 1')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [{ operator: '==', version: '1' }],
-        })
-    })
-    it('should parse package name with partial dot version', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip == 1.')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [{ operator: '==', version: '1.' }],
-        })
-    })
-    it('should parse package name with partial second version number', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip == 1.2')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [{ operator: '==', version: '1.2' }],
-        })
-    })
-
-    // Auto-completion scenarios
-    it('should parse package name with opening bracket for extras', () => {
-        const requirement = parsePipRequirementsLineLoosely('requests[')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'requests',
-            extras: [],
-        })
-    })
-    it('should parse package name with partial extra being typed', () => {
-        const requirement = parsePipRequirementsLineLoosely('requests[sec')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'requests',
-            extras: ['sec'],
-        })
-    })
-    it('should parse package name with complete extra and comma', () => {
-        const requirement = parsePipRequirementsLineLoosely('requests[security,')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'requests',
-            extras: ['security'],
-        })
-    })
-    it('should parse package name with opening parenthesis for version', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip (')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [],
-        })
-    })
-    it('should parse package name with opening parenthesis and partial operator', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip (>')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [{ operator: '>' }],
-        })
-    })
-
-    // Typos and corrections
-    it('should parse package name with wrong operator being corrected', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip =<')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [{ operator: '=<' }],
-        })
-    })
-    it('should parse package name with double operators', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip >>>')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [{ operator: '>>>' }],
-        })
-    })
-    it('should parse package name with mixed operator characters', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip >=<')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [{ operator: '>=<' }],
-        })
-    })
-    it('should parse package name with incomplete version after space', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip == 1.')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [{ operator: '==', version: '1.' }],
-        })
-    })
-
-    // Copy-paste fragments and partial inputs
-    it('should parse incomplete requirements line ending abruptly', () => {
-        const requirement = parsePipRequirementsLineLoosely('django>=3.2,<4.0,!=3.2.1')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'django',
-            versionSpec: [
-                { operator: '>=', version: '3.2' },
-                { operator: '<', version: '4.0' },
-                { operator: '!=', version: '3.2.1' },
-            ],
-        })
-    })
-    it('should parse requirement with dangling comma', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip>=1.0,')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [{ operator: '>=', version: '1.0' }],
-        })
-    })
-    it('should parse requirement with multiple dangling commas', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip>=1.0,,,')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [{ operator: '>=', version: '1.0' }],
-        })
-    })
-    it('should parse requirement with space before comma', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip>=1.0 ,<2.0')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [
-                { operator: '>=', version: '1.0' },
-                { operator: '<', version: '2.0' },
-            ],
-        })
-    })
-
-    // Complex progressive typing with multiple elements
-    it('should parse progressive complex requirement building', () => {
-        const requirement = parsePipRequirementsLineLoosely('requests[security,socks](>=2.25.1,<3.0')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'requests',
-            extras: ['security', 'socks'],
-            versionSpec: [
-                { operator: '>=', version: '2.25.1' },
-                { operator: '<', version: '3.0' },
-            ],
-        })
-    })
-    it('should parse package with extras and incomplete version in parentheses', () => {
-        const requirement = parsePipRequirementsLineLoosely('package[extra](==')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'package',
-            extras: ['extra'],
-            versionSpec: [{ operator: '==' }],
-        })
-    })
-    it('should parse package with incomplete extras and version', () => {
-        const requirement = parsePipRequirementsLineLoosely('package[extra>=1.0')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'package',
-            extras: ['extra'],
-            versionSpec: [{ operator: '>=', version: '1.0' }],
-        })
-    })
-
-    // Edge cases with numbers and special characters in names/versions
-    it('should parse package names starting with numbers', () => {
-        const requirement = parsePipRequirementsLineLoosely('2to3')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: '2to3',
-        })
-    })
-    it('should parse package names with numbers and special chars', () => {
-        const requirement = parsePipRequirementsLineLoosely('py2-ipaddress >= 3.4')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'py2-ipaddress',
-            versionSpec: [{ operator: '>=', version: '3.4' }],
-        })
-    })
-    it('should parse alpha/beta/rc versions being typed', () => {
-        const requirement = parsePipRequirementsLineLoosely('package == 1.0a')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'package',
-            versionSpec: [{ operator: '==', version: '1.0a' }],
-        })
-    })
-    it('should parse dev versions being typed', () => {
-        const requirement = parsePipRequirementsLineLoosely('package == 1.0.dev')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'package',
-            versionSpec: [{ operator: '==', version: '1.0.dev' }],
-        })
-    })
-
-    // Realistic backspacing scenarios (what's left after partial deletion)
-    it('should parse after backspacing part of version', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip == 1.0.')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [{ operator: '==', version: '1.0.' }],
-        })
-    })
-    it('should parse after backspacing closing bracket', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip[extra')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            extras: ['extra'],
-        })
-    })
-    it('should parse after backspacing part of operator', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip >')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [{ operator: '>' }],
-        })
-    })
-
-    // Environment marker edge cases
-    it('should parse with incomplete environment marker', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip >= 1.0 ; python_version')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [{ operator: '>=', version: '1.0' }],
-        })
-    })
-    it('should parse with semicolon but no marker', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip >= 1.0 ;')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [{ operator: '>=', version: '1.0' }],
-        })
-    })
-    it('should parse with semicolon and partial marker text', () => {
-        const requirement = parsePipRequirementsLineLoosely('pip >= 1.0 ; sys_plat')
-        expect(requirement).toEqual({
-            type: 'ProjectName',
-            name: 'pip',
-            versionSpec: [{ operator: '>=', version: '1.0' }],
+    describe('with location tracking', () => {
+        looseParsingTests.forEach(([explanation, input, expected]) => {
+            it(explanation, () => {
+                const requirement = parsePipRequirementsLineLoosely(input, { includeLocations: true })
+                expect(requirement).toEqual(expected)
+            })
         })
     })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,42 +1,90 @@
 import grammar from './pep-508.ohm-bundle'
 import { RequirementsSyntaxError, semantics } from './semantics'
-import { LooseProjectNameRequirement, Requirement } from './types'
+import { LooseProjectNameRequirement, Requirement, WithLocation } from './types'
 
 export { RequirementsSyntaxError } from './semantics'
 export * from './types'
 
 /** Parse file content according to the full rules of pip requirements syntax. */
-export function parsePipRequirementsFile(fileContent: string): Requirement[] {
+export function parsePipRequirementsFile(fileContent: string): Requirement[]
+export function parsePipRequirementsFile(
+    fileContent: string,
+    options: { includeLocations: true }
+): WithLocation<Requirement>[]
+export function parsePipRequirementsFile(
+    fileContent: string,
+    options?: { includeLocations?: boolean }
+): Requirement[] | WithLocation<Requirement>[] {
     const matchResult = grammar.match(fileContent, 'File')
     if (matchResult.failed()) {
         throw new RequirementsSyntaxError(`Failed to parse requirements file. ${matchResult.shortMessage}`)
+    }
+
+    if (options?.includeLocations) {
+        return semantics(matchResult).extractWithLocation()
     }
     return semantics(matchResult).extract()
 }
 
 /** Parse line content according to the full rules of pip requirements syntax. */
-export function parsePipRequirementsLine(lineContent: string): Requirement | null {
+export function parsePipRequirementsLine(lineContent: string): Requirement | null
+export function parsePipRequirementsLine(
+    lineContent: string,
+    options: { includeLocations: true }
+): WithLocation<Requirement> | null
+export function parsePipRequirementsLine(
+    lineContent: string,
+    options?: { includeLocations?: boolean }
+): Requirement | WithLocation<Requirement> | null {
     const matchResult = grammar.match(lineContent, 'Line')
     if (matchResult.failed()) {
         throw new RequirementsSyntaxError(`Failed to parse requirements line. ${matchResult.shortMessage}`)
+    }
+
+    if (options?.includeLocations) {
+        return semantics(matchResult).extractWithLocation()
     }
     return semantics(matchResult).extract()
 }
 
 /** Parse file content in loose mode that only extracts project name requirements. Intended for content being edited. */
-export function parsePipRequirementsFileLoosely(fileContent: string): LooseProjectNameRequirement[] {
+export function parsePipRequirementsFileLoosely(fileContent: string): LooseProjectNameRequirement[]
+export function parsePipRequirementsFileLoosely(
+    fileContent: string,
+    options: { includeLocations: true }
+): WithLocation<LooseProjectNameRequirement>[]
+export function parsePipRequirementsFileLoosely(
+    fileContent: string,
+    options?: { includeLocations?: boolean }
+): LooseProjectNameRequirement[] | WithLocation<LooseProjectNameRequirement>[] {
     const matchResult = grammar.match(fileContent, 'LooseFile')
     if (matchResult.failed()) {
         throw new RequirementsSyntaxError(`Failed to loosely parse requirements file. ${matchResult.shortMessage}`)
+    }
+
+    if (options?.includeLocations) {
+        return semantics(matchResult).extractLooselyWithLocation()
     }
     return semantics(matchResult).extractLoosely()
 }
 
 /** Parse line content in loose mode that only extracts project name requirements. Intended for content being edited. */
-export function parsePipRequirementsLineLoosely(lineContent: string): LooseProjectNameRequirement | null {
+export function parsePipRequirementsLineLoosely(lineContent: string): LooseProjectNameRequirement | null
+export function parsePipRequirementsLineLoosely(
+    lineContent: string,
+    options: { includeLocations: true }
+): WithLocation<LooseProjectNameRequirement> | null
+export function parsePipRequirementsLineLoosely(
+    lineContent: string,
+    options?: { includeLocations?: boolean }
+): LooseProjectNameRequirement | WithLocation<LooseProjectNameRequirement> | null {
     const matchResult = grammar.match(lineContent, 'LooseLine')
     if (matchResult.failed()) {
         throw new RequirementsSyntaxError(`Failed to loosely parse requirements line. ${matchResult.shortMessage}`)
+    }
+
+    if (options?.includeLocations) {
+        return semantics(matchResult).extractLooselyWithLocation()
     }
     return semantics(matchResult).extractLoosely()
 }

--- a/src/pep-508.ohm
+++ b/src/pep-508.ohm
@@ -105,12 +105,12 @@ PEP508 {
     LooseReq          = LooseNonNameReq | LooseNameReq
     LooseNameReq      = Name LooseExtras? LooseVersionSpec LooseQuotedMarker?
     LooseNonNameReq   = (~(~(Name "@") Name) looseAnything) // Non-name req can start with Name only if followed by "@"
-    LooseExtras       = "[" (ListOf<identifier, ","> "]"?)?
+    LooseExtras       = "[" ListOf<identifier, ","> ","* "]"?
     LooseQuotedMarker = ";" looseAnything
-    LooseVersionSpec  = "(" (LooseVersionMany ")"?)? -- parenthesized
+    LooseVersionSpec  = "(" LooseVersionMany ")"? -- parenthesized
                       | LooseVersionMany -- direct
-    LooseVersionMany  = ListOf<LooseVersionOne, ","> ","?
-    LooseVersionOne   = (looseVersionCmp looseVersion?)?
+    LooseVersionMany  = ListOf<LooseVersionOne, ","> ","*
+    LooseVersionOne   = looseVersionCmp looseVersion?
     looseVersionCmp   = ("<" | "=" | "!" | ">" | "~")+
     looseVersion      = (alnum | "-" | "_" | "." | "*" | "+" | "!" )+
     looseAnything     = (~("\n" | "#") any)* // Any non-comment line content

--- a/src/semantics.ts
+++ b/src/semantics.ts
@@ -1,4 +1,4 @@
-import grammar, { PEP508ActionDict } from './pep-508.ohm-bundle'
+import grammar from './pep-508.ohm-bundle'
 import {
     Requirement,
     ProjectNameRequirement,
@@ -34,7 +34,7 @@ function withLocation<T>(node: any, data: T): WithLocation<T> {
     }
 }
 
-const STRICT_EXTRACTION_ACTION_DICT: PEP508ActionDict<any> = {
+semantics.addOperation<any>('extract', {
     /* eslint-disable @typescript-eslint/no-unused-vars */
     File: (linesList): Requirement[] =>
         linesList
@@ -101,9 +101,9 @@ const STRICT_EXTRACTION_ACTION_DICT: PEP508ActionDict<any> = {
         version: version.sourceString,
     }),
     /* eslint-enable @typescript-eslint/no-unused-vars */
-}
+})
 
-const LOOSE_EXTRACTION_ACTION_DICT: PEP508ActionDict<any> = {
+semantics.addOperation<any>('extractLoosely', {
     /* eslint-disable @typescript-eslint/no-unused-vars */
     LooseFile: (linesList): LooseProjectNameRequirement[] =>
         linesList
@@ -142,9 +142,9 @@ const LOOSE_EXTRACTION_ACTION_DICT: PEP508ActionDict<any> = {
         return result
     },
     /* eslint-enable @typescript-eslint/no-unused-vars */
-}
+})
 
-const STRICT_EXTRACTION_WITH_LOCATION_ACTION_DICT: PEP508ActionDict<any> = {
+semantics.addOperation<any>('extractWithLocation', {
     /* eslint-disable @typescript-eslint/no-unused-vars */
     File: (linesList): Requirement[] =>
         linesList
@@ -224,9 +224,9 @@ const STRICT_EXTRACTION_WITH_LOCATION_ACTION_DICT: PEP508ActionDict<any> = {
         })
     },
     /* eslint-enable @typescript-eslint/no-unused-vars */
-}
+})
 
-const LOOSE_EXTRACTION_WITH_LOCATION_ACTION_DICT: PEP508ActionDict<any> = {
+semantics.addOperation<any>('extractLooselyWithLocation', {
     /* eslint-disable @typescript-eslint/no-unused-vars */
     LooseFile: (linesList): LooseProjectNameRequirement[] =>
         linesList
@@ -266,13 +266,6 @@ const LOOSE_EXTRACTION_WITH_LOCATION_ACTION_DICT: PEP508ActionDict<any> = {
         })
     },
     /* eslint-enable @typescript-eslint/no-unused-vars */
-}
-
-/* eslint-disable @typescript-eslint/no-explicit-any */
-semantics.addOperation<any>('extract', STRICT_EXTRACTION_ACTION_DICT)
-semantics.addOperation<any>('extractLoosely', LOOSE_EXTRACTION_ACTION_DICT)
-semantics.addOperation<any>('extractWithLocation', STRICT_EXTRACTION_WITH_LOCATION_ACTION_DICT)
-semantics.addOperation<any>('extractLooselyWithLocation', LOOSE_EXTRACTION_WITH_LOCATION_ACTION_DICT)
-/* eslint-enable @typescript-eslint/no-explicit-any */
+})
 
 export class RequirementsSyntaxError extends Error {}

--- a/src/semantics.ts
+++ b/src/semantics.ts
@@ -171,8 +171,8 @@ semantics.addOperation<any>('extractWithLocation', {
             environmentMarkerTree: markers.child(0)?.extractWithLocation(),
         })
     },
-    Extras: function (_open, extrasList, _close): string[] {
-        return extrasList.asIteration().children.map((extra) => extra.sourceString)
+    Extras: function (_open, extrasList, _close): WithLocation<string>[] {
+        return extrasList.asIteration().children.map((extra) => withLocation<string>(extra, extra.sourceString))
     },
     RequirementsReq: function (_dashR, filePath) {
         return withLocation(this, {
@@ -246,8 +246,8 @@ semantics.addOperation<any>('extractLooselyWithLocation', {
     },
     LooseNonNameReq: (_) => null,
 
-    LooseExtras: function (_open, extrasList, _trailingComma, _close): string[] {
-        return extrasList.asIteration().children.map((extra) => extra.sourceString)
+    LooseExtras: function (_open, extrasList, _trailingComma, _close): WithLocation<string>[] {
+        return extrasList.asIteration().children.map((extra) => withLocation<string>(extra, extra.sourceString))
     },
 
     LooseVersionSpec_parenthesized: (_open, versionMany, _close): string[] =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,3 +124,13 @@ export interface LooseVersionSpec {
     operator: string
     version?: string
 }
+
+export interface SourceLocation {
+    startIdx: number
+    endIdx: number
+}
+
+export interface WithLocation<T> {
+    data: T
+    location: SourceLocation
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,4 +116,11 @@ export enum VersionOperator {
 export interface LooseProjectNameRequirement {
     type: 'ProjectName'
     name: string
+    versionSpec?: LooseVersionSpec[]
+    extras?: string[]
+}
+
+export interface LooseVersionSpec {
+    operator: string
+    version?: string
 }


### PR DESCRIPTION
This adds two new features:

It's now possible to optionally include node location data by passing `{ includeLocations: true }` on any `parse...` function.

Also, loosely-parsed requirements now return version specs and extras.

BEGIN_COMMIT_OVERRIDE
feat: Add `includeLocations` parsing option

feat: Include version specs & extras in loose mode
END_COMMIT_OVERRIDE